### PR TITLE
explicitly include commdlg.h so that the project works in a lean solution

### DIFF
--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <windows.h>
+#include <commdlg.h>
 #include <shlobj.h>
 
 


### PR DESCRIPTION
I like to compile all my projects with the 'WIN32_LEAN_AND_MEAN' flag, so compile times stay reasonable. For this to work we have to include commdlg.h explicitly.
