### PR TITLE
move char buffer variable one closure up to avoid invalid char pointer

### DIFF
--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -58,6 +58,7 @@ char *osdialog_file(osdialog_file_action action, const char *path, const char *f
 		}
 	}
 	else {
+		char fBuf[4096];
 		// open or save file dialog
 		OPENFILENAME ofn;
 		ZeroMemory(&ofn, sizeof(ofn));
@@ -74,7 +75,6 @@ char *osdialog_file(osdialog_file_action action, const char *path, const char *f
 		ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 
 		if (filters) {
-			char fBuf[4096];
 			int fLen = 0;
 
 			for (; filters; filters = filters->next) {


### PR DESCRIPTION
The assignement `ofn.lpstrFilter = fBuf` will be invalid once the enclosing if statement is left, because fBuf will be of undefined state at this point.