### PR TITLE
On Windows, re-open directory dialog with last directory used.

### DIFF
--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -32,6 +32,14 @@ int osdialog_message(osdialog_message_level level, osdialog_message_buttons butt
 	}
 }
 
+int CALLBACK osdialog_browseCallbackProc( HWND hWnd, UINT uMsg, LPARAM lParam,
+  LPARAM lpData )
+{
+  if (uMsg == BFFM_INITIALIZED)
+    SendMessage(hWnd, BFFM_SETSELECTION,TRUE, lpData);
+  return 0;
+}
+
 char *osdialog_file(osdialog_file_action action, const char *path, const char *filename, osdialog_filters *filters) {
 	if (action == OSDIALOG_OPEN_DIR) {
 		// open directory dialog
@@ -43,7 +51,9 @@ char *osdialog_file(osdialog_file_action action, const char *path, const char *f
 		bInfo.pidlRoot = NULL;
 		bInfo.pszDisplayName = szDir;
 		bInfo.lpszTitle = NULL;
-		bInfo.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI;
+		bInfo.ulFlags = BIF_RETURNONLYFSDIRS;
+		bInfo.lpfn = osdialog_browseCallbackProc;
+		bInfo.lParam = (LPARAM)path;
 		bInfo.lpfn = NULL;
 		bInfo.lParam = 0;
 		bInfo.iImage = -1;


### PR DESCRIPTION
On Windows, the directory selection dialog does not ~~remember~~ show the directory passed in. This PR fixes the issue.

The general approach to the solution is described [here](https://www.codeproject.com/articles/20853/%2fArticles%2f20853%2fWin32-Tips-and-Tricks#browse1). 

Microsoft [documentation ](https://docs.microsoft.com/en-us/windows/desktop/api/shlobj_core/nf-shlobj_core-shbrowseforfolderw) for `SHBrowseForFolderW` states:
"If you implement a callback function, specified in the lpfn member of the BROWSEINFO structure, you receive a handle to the dialog box. One use of this window handle is to modify the layout or contents of the dialog box. Because it is not resizable, modifying the older style dialog box is relatively straightforward. **Modifying the newer style dialog box is much more difficult, and not recommended. Not only does it have a different size and layout than the old style, but its dimensions and the positions of its controls change every time it is resized by the user.**"

Why is this important? The current implementation uses the new style dialog box. The issue with the callback solution is that the current directory is not "focused" in the directory box when using the new style box. The user still has to scroll to get to the currently selected directory to change it. The old style dialog box focuses correctly and the user can very quickly select a new directory at the same level. Therefore, the dialog box style was changed to old style box for this solution.

