### PR TITLE
Fix build problems with MSVC

### DIFF
--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -117,7 +117,7 @@ char* osdialog_file(osdialog_file_action action, const char* path, const char* f
 		wchar_t strFile[MAX_PATH] = L"";
 		if (filename) {
 			wchar_t* filenameW = utf8_to_wchar(filename);
-			snwprintf(strFile, MAX_PATH, L"%S", filenameW);
+			wcsncpy_s(strFile, MAX_PATH, filenameW, _TRUNCATE);
 			OSDIALOG_FREE(filenameW);
 		}
 		ofn.lpstrFile = strFile;

--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -71,9 +71,9 @@ char* osdialog_prompt(osdialog_message_level level, const char* message, const c
 }
 
 
-static INT CALLBACK browseCallbackProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
+static INT CALLBACK browseCallbackProc(HWND hWnd, UINT Msg, LPARAM lParam, LPARAM lpData) {
 	if (Msg == BFFM_INITIALIZED) {
-		SendMessageW(hWnd, BFFM_SETEXPANDED, 1, lParam);
+		SendMessageW(hWnd, BFFM_SETEXPANDED, 1, lpData);
 	}
 	return 0;
 }


### PR DESCRIPTION
Hi, this fixes the build with Visual Studio 2019.
- This replaces the missing function `snwprintf`. (and the replacement `_snwprintf` appears to be incompatible)
- Suppresses a warning caused by a callback function with a wrong signature.