### PR TITLE
Set given color as initial color in gtk color picker

### DIFF
--- a/osdialog_gtk2.c
+++ b/osdialog_gtk2.c
@@ -181,10 +181,22 @@ int osdialog_color_picker(osdialog_color* color, int opacity) {
 	GtkWidget* dialog = gtk_color_chooser_dialog_new("Color", NULL);
 	GtkColorChooser* colorsel = GTK_COLOR_CHOOSER(dialog);
 	gtk_color_chooser_set_use_alpha(colorsel, opacity);
+	GdkRGBA c;
+	c.red = color->r / 255.0;
+	c.green = color->g / 255.0;
+	c.blue = color->b / 255.0;
+	c.alpha = color->a / 255.0;
+	gtk_color_chooser_set_rgba(colorsel, &c);
 #else
 	GtkWidget* dialog = gtk_color_selection_dialog_new("Color");
 	GtkColorSelection* colorsel = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(GTK_COLOR_SELECTION_DIALOG(dialog)));
 	gtk_color_selection_set_has_opacity_control(colorsel, opacity);
+	GdkColor c;
+	c.red = color->r << 8;
+	c.green = color->g << 8;
+	c.blue = color->b << 8;
+	gtk_color_selection_set_current_color(colorsel, &c);
+	gtk_color_selection_set_current_alpha(colorsel, color->a << 8);
 #endif
 
 	int result = 0;

--- a/osdialog_gtk2.c
+++ b/osdialog_gtk2.c
@@ -204,10 +204,10 @@ int osdialog_color_picker(osdialog_color* color, int opacity) {
 #ifdef OSDIALOG_GTK3
 		GdkRGBA c;
 		gtk_color_chooser_get_rgba(colorsel, &c);
-		color->r = c.red * 65535 + 0.5;
-		color->g = c.green * 65535 + 0.5;
-		color->b = c.blue * 65535 + 0.5;
-		color->a = c.alpha * 65535 + 0.5;
+		color->r = c.red * 255;
+		color->g = c.green * 255;
+		color->b = c.blue * 255;
+		color->a = c.alpha * 255;
 #else
 		GdkColor c;
 		gtk_color_selection_get_current_color(colorsel, &c);


### PR DESCRIPTION
- Sets the given color as initial color. Keeps the given value if the users doesn't change the color dialog. `gtk2` Example when passing an initial color of `r: 200,g: 255, b: 255, a: 100`:

  Currently it's always:
  ![Screenshot_20231006_182452](https://github.com/AndrewBelt/osdialog/assets/34311583/1a5066a8-b785-465f-ae3e-1689949c54b6)
  When the user chooses okay, the color `r: 255, g: 255, b: 255, a: 255` is returned, no matter the initial input.

  Now, it opens with the values that are passed initially:
  ![Screenshot_20231006_182514](https://github.com/AndrewBelt/osdialog/assets/34311583/c424917a-31e4-49fa-8093-373da208bccd)
  and keeps them when confirming the dialog without further changes.
  
  This would resemble the behavior of the color picker windows.