### PR TITLE
snwprintf -> _snwprintf

### DIFF
--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -297,7 +297,7 @@ char* osdialog_file(osdialog_file_action action, const char* dir, const char* fi
 		wchar_t strFile[MAX_PATH] = L"";
 		if (filename) {
 			wchar_t* filenameW = utf8_to_wchar(filename);
-			snwprintf(strFile, MAX_PATH, L"%S", filenameW);
+			_snwprintf(strFile, MAX_PATH, L"%S", filenameW);
 			OSDIALOG_FREE(filenameW);
 		}
 		ofn.lpstrFile = strFile;


### PR DESCRIPTION
In Windows dev kit 10.0.22621.0 that installed with Visual Studio 2022, snwprintf is renamed to _snwprintf. To stay compatible with older versions, adding `#define _snwprintf snwprintf` probably works too.