### PR TITLE
Fix MSVC compatibility by using `vswprintf`  instead of `snwprintf`

### DIFF
--- a/osdialog_win.c
+++ b/osdialog_win.c
@@ -297,7 +297,7 @@ char* osdialog_file(osdialog_file_action action, const char* dir, const char* fi
 		wchar_t strFile[MAX_PATH] = L"";
 		if (filename) {
 			wchar_t* filenameW = utf8_to_wchar(filename);
-			snwprintf(strFile, MAX_PATH, L"%S", filenameW);
+			vswprintf(strFile, MAX_PATH, L"%S", filenameW);
 			OSDIALOG_FREE(filenameW);
 		}
 		ofn.lpstrFile = strFile;


### PR DESCRIPTION
I was running into the issue of not being able to use the library with MSVC.

```
osdialog.lib(osdialog_win.obj) : error LNK2019: unresolved external symbol snwprintf referenced in function osdialog_file
C:\Users\vboxuser\Dev\main.exe : fatal error LNK1120: 1 unresolved externals
```

Reason is that `snwprintf` is not available in MSVC. Instead, MSVC provides `_snwprintf`. Though to ensure compatibility with both MSVC and MinGW, I changed it to a `vswprintf` call.
